### PR TITLE
Support 'for .. in' expressions

### DIFF
--- a/FSharp.Control.FusionTasks.FS3PCL47/AsyncExtensions.fs
+++ b/FSharp.Control.FusionTasks.FS3PCL47/AsyncExtensions.fs
@@ -166,3 +166,13 @@ module AsyncExtensions =
     /// <returns>F# Async</returns>
     member __.Source(cta: ConfiguredAsyncAwaitable<'T>) =
       Infrastructures.asAsyncCTAT(cta)
+
+    /// <summary>
+    /// Accept any sequence type to support `for .. in` expressions in Async workflows.
+    /// </summary>
+    /// <typeparam name="'E">The element type of the sequence</typeparam> 
+    /// <param name="s">The sequence.</param>
+    /// <returns>F# Async</returns>
+    member __.Source(s: 'R seq) =
+      s
+    

--- a/FSharp.Control.FusionTasksTests.FS3PCL47/AsyncExtensionsTests.fs
+++ b/FSharp.Control.FusionTasksTests.FS3PCL47/AsyncExtensionsTests.fs
@@ -98,3 +98,12 @@ let AsyncBuilderWithAsyncAndTaskCombinationTest() =
       do ms.ToArray() |> should equal data
     }
   computation |> Async.RunSynchronously  // FSUnit not supported Async/Task based tests, so run synchronously here. 
+
+[<Test>]
+let AsyncBuilderCompilesForInTest() =
+  let computation = async {
+        for i in {0..1} do
+            ()
+    }
+
+  computation |> Async.RunSynchronously  // FSUnit not supported Async/Task based tests, so run synchronously here. 


### PR DESCRIPTION
The `Source` method of Async builders was very new to me when I took a closer look at how FusionTasks were able to fix all these type inferencer problems that appeared when I tried to support .NET Tasks. So I immediately adapted the builder and recognized that somehow the sequence parameter to a `for .. in` expression also needs to go through the `Source` overloads as soon one of them were declared.